### PR TITLE
fix: query exchanges before the selected year

### DIFF
--- a/app/controllers/exchange_events_controller.rb
+++ b/app/controllers/exchange_events_controller.rb
@@ -6,7 +6,7 @@ class ExchangeEventsController < ApplicationController
   end
 
   def new
-    year = 2000
+    year = Time.zone.now.year
     exchange_event = ExchangeEvent.new(user: current_user, year: year)
     participants = Member.where(user: current_user).includes(:family, :exchanges_as_sender)
 

--- a/app/models/exchange_event.rb
+++ b/app/models/exchange_event.rb
@@ -36,9 +36,9 @@ class ExchangeEvent < ApplicationRecord
         end
 
         # 2. A family member can only be paired with the same Secret Santa once every three years.
-        exchanges = @participants[i].exchanges_as_sender.pluck(:recipient_id, :year)
+        exchanges = @participants[i].exchanges_as_sender.where('year < ?', @year).pluck(:recipient_id, :year)
         exchanges.each do |recipient_id, year|
-          if recipient_id == @participants[j].id && Time.zone.now.year - year < 3
+          if recipient_id == @participants[j].id && @year - year < 3
             graph[i][j] = false
             break
           end


### PR DESCRIPTION
# This PR

Fixes the query to get exchanges from database that are before the selected year

# Issue

Closes #22 